### PR TITLE
switch model to 1.0-pro

### DIFF
--- a/genkit-functions/prompts/itineraryGen.prompt
+++ b/genkit-functions/prompts/itineraryGen.prompt
@@ -1,5 +1,5 @@
 ---
-model: vertexai/gemini-1.5-pro-preview
+model: vertexai/gemini-1.0-pro-preview
 config:
   temperature: 1.0
 input:


### PR DESCRIPTION
Fixes #

Step 8. https://firebase.google.com/codelabs/ai-genkit-rag#7

It fails with the following error: 
 ⨯ Error: Vertex response generation failed: ClientError: [VertexAI.ClientError]: got status: 429 Too Many Requests. {"error":{"code":429,"message":"Quota exceeded for aiplatform.googleapis.com/generate_content_requests_per_minute_per_project_per_base_model with base model: gemini-1.5-flash. Please submit a quota increase request. https://cloud.google.com/vertex-ai/docs/generative-ai/quotas-genai.","status":"RESOURCE_EXHAUSTED"}}
    at Generator.throw (<anonymous>)
digest: "764727645"
 POST /gemini 500 in 2669ms

When moving to gemini-1.0-pro-previw it passes. Flash creates the same issue on my side. I guess because of: https://cloud.google.com/vertex-ai/generative-ai/docs/quotas